### PR TITLE
Workaround for webdav server returning 405 to HEAD requests

### DIFF
--- a/RemoteCloud/RemoteCloud/Storages/WebDAVStorage.swift
+++ b/RemoteCloud/RemoteCloud/Storages/WebDAVStorage.swift
@@ -262,6 +262,14 @@ class ViewControllerWebDAV: UIViewController, UITextFieldDelegate, URLSessionTas
             }
             
             /* Only check HEAD for non-Caddy webdav servers */
+            guard let server = response.allHeaderFields["Server"] as? String else {
+                print(response)
+                DispatchQueue.main.async {
+                    self.activityIndicatorView.stopAnimating()
+                }
+                return
+            }
+            
             if server.contains("Caddy") {
                 done = true
                 onFinish(uri, user, pass)

--- a/RemoteCloud/RemoteCloud/Storages/WebDAVStorage.swift
+++ b/RemoteCloud/RemoteCloud/Storages/WebDAVStorage.swift
@@ -261,17 +261,24 @@ class ViewControllerWebDAV: UIViewController, UITextFieldDelegate, URLSessionTas
                 return
             }
             
-            guard let url = URL(string: uri) else {
-                DispatchQueue.main.async {
-                    self.activityIndicatorView.stopAnimating()
-                }
-                return
+            /* Only check HEAD for non-Caddy webdav servers */
+            if server.contains("Caddy") {
+                done = true
+                onFinish(uri, user, pass)
+            } else {
+           
+               guard let url = URL(string: uri) else {
+                    DispatchQueue.main.async {
+                        self.activityIndicatorView.stopAnimating()
+                    }
+                    return
+               }
+                var request: URLRequest = URLRequest(url: url)
+                request.httpMethod = "HEAD"
+                let task = dataSession.dataTask(with: request)
+                testState = 1
+                task.resume()
             }
-            var request: URLRequest = URLRequest(url: url)
-            request.httpMethod = "HEAD"
-            let task = dataSession.dataTask(with: request)
-            testState = 1
-            task.resume()
         }
         else if testState == 1 {
             done = true

--- a/RemoteCloud/RemoteCloud/Storages/WebDAVStorage.swift
+++ b/RemoteCloud/RemoteCloud/Storages/WebDAVStorage.swift
@@ -268,10 +268,6 @@ class ViewControllerWebDAV: UIViewController, UITextFieldDelegate, URLSessionTas
                 return
             }
             
-            /*
-                `rclone serve webdav` does not return Server field, but do suport HEAD request.
-                Caddyv2+webdav, on the contrary, returns Server field, but does NOT support HEAD.
-            */
             if let server = response.allHeaderFields["Server"] as? String {
                 /* Only check HEAD for non-Caddy webdav servers */
                 if server.contains("Caddy") {
@@ -284,6 +280,7 @@ class ViewControllerWebDAV: UIViewController, UITextFieldDelegate, URLSessionTas
             let task = dataSession.dataTask(with: request)
             testState = 1
             task.resume()
+
         }
         else if testState == 1 {
             done = true


### PR DESCRIPTION
Viewer submits OPTION and then HEAD to webdav server. The second request fails with 405 for Caddy2+WebDAV server. Choose to skip HEAD request.